### PR TITLE
Detach and clone camera before preprocessing

### DIFF
--- a/data/blender.py
+++ b/data/blender.py
@@ -50,6 +50,8 @@ class Dataset(base.Dataset):
         image = self.images[idx] if opt.data.preload else self.get_image(opt,idx)
         image = self.preprocess_image(opt,image,aug=aug)
         intr,pose = self.cameras[idx] if opt.data.preload else self.get_camera(opt,idx)
+        intr = intr.detach().clone()
+        pose = pose.detach().clone()
         intr,pose = self.preprocess_camera(opt,intr,pose,aug=aug)
         sample.update(
             image=image,

--- a/data/iphone.py
+++ b/data/iphone.py
@@ -48,6 +48,8 @@ class Dataset(base.Dataset):
         image = self.images[idx] if opt.data.preload else self.get_image(opt,idx)
         image = self.preprocess_image(opt,image,aug=aug)
         intr,pose = self.cameras[idx] if opt.data.preload else self.get_camera(opt,idx)
+        intr = intr.detach().clone()
+        pose = pose.detach().clone()
         intr,pose = self.preprocess_camera(opt,intr,pose,aug=aug)
         sample.update(
             image=image,

--- a/data/llff.py
+++ b/data/llff.py
@@ -80,6 +80,8 @@ class Dataset(base.Dataset):
         image = self.images[idx] if opt.data.preload else self.get_image(opt,idx)
         image = self.preprocess_image(opt,image,aug=aug)
         intr,pose = self.cameras[idx] if opt.data.preload else self.get_camera(opt,idx)
+        intr = intr.detach().clone()
+        pose = pose.detach().clone()
         intr,pose = self.preprocess_camera(opt,intr,pose,aug=aug)
         sample.update(
             image=image,


### PR DESCRIPTION
Detach and clone camera pose and intrinsics before pre-processing. The argument passed to preprocess_camera() is passed by reference, so the underlying pose gets modified every time the function is ran. As a result, the intrinsics are, incorrectly, modified more than once. This PR clones the pose and intrinsics before pre-processing, avoiding this issue.