### PR TITLE
Functionality to train BARF on AzureML

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ It is recommended use [Anaconda](https://www.anaconda.com/products/individual) t
 conda env create --file requirements.yaml python=3
 conda activate barf-env
 ```
+If you plan to use the infrastructure to train on AzureML, please install with the other requirement file.
+```bash
+conda env create --file requirements_azureml.yaml python=3
+conda activate barf-env
+```
 Initialize the external submodule dependencies with
 ```bash
 git submodule update --init --recursive

--- a/azureml/default_azureml_config.yaml
+++ b/azureml/default_azureml_config.yaml
@@ -1,0 +1,30 @@
+{
+    "subscription_id": "{your subscription id}",
+    "resource_group": "{your resource group}",
+    "workspace_name": "{your workspace name}",
+    "datastore": "{your datastore}",
+    "data_dir": "{path to the root of your data on the datastore}",
+    "compute_name": "{your compute name}",
+
+    "experiment_name": "barf",
+    "entry_script": "train_azureml.py",
+
+    "node_count": 1,
+    "max_total_runs": 32,
+    "primary_metric_name": "error_t",
+
+    "script_args": [
+        "--group=group", 
+        "--model=barf", 
+        "--yaml=barf_blender", 
+        "--name=baseline", 
+        "--output_root=./outputs",
+        "--barf_c2f=[0.1,0.5]",
+        "--visdom!"
+    ],
+
+    "param_sampling": {
+        "--data.scene": "choice('{scene_1}', '{scene_2}', '{scene_3}')"
+    }
+
+}

--- a/azureml/run_train_azureml.py
+++ b/azureml/run_train_azureml.py
@@ -1,0 +1,80 @@
+# azureml/run-train.py
+from azureml.core.workspace import Workspace
+from azureml.core import Experiment
+from azureml.core import Environment
+from azureml.core import ScriptRunConfig
+from azureml.core import Dataset
+
+import azureml.train.hyperdrive as hyperdrive
+from azureml.train.hyperdrive.parameter_expressions import choice
+
+import argparse
+import json, os
+
+def get_hyperparam_dict(run_config):
+    param_dict = run_config["param_sampling"]
+    for key, value in param_dict.items():
+        exec("param_dict[key] = " + value)
+
+    return param_dict
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_config_path", help="Path to the run config yaml file")
+    parser.add_argument("run_name", help="Name of the newly created run")
+    args = parser.parse_args()
+
+    with open(args.run_config_path, "r") as f:
+        run_config = json.load(f)
+
+    workspace = Workspace(run_config["subscription_id"], run_config["resource_group"], run_config["workspace_name"])
+
+    if "datastore" in run_config:
+        print("Using non-default datastore")
+        datastore = workspace.datastores[run_config["datastore"]]
+    else:
+        datastore = workspace.get_default_datastore()
+
+    ds_path=""
+    asset_dir = datastore.path(ds_path).as_mount()
+    dataset = Dataset.File.from_files(path=(datastore, run_config["data_dir"]))
+    
+    compute_target = workspace.compute_targets[run_config["compute_name"]]
+    project_folder = os.path.join(os.path.dirname(__file__), "..")
+    env_requirements = os.path.join(project_folder, "requirements_azureml.yaml")
+
+    barf_env = Environment.from_conda_specification(name="barf-env", file_path=env_requirements)
+
+    arguments = run_config["script_args"]+[dataset.as_named_input('input').as_mount()]
+
+    hyperparam_dict = get_hyperparam_dict(run_config)
+
+    src = ScriptRunConfig(source_directory=project_folder,
+                          script=run_config["entry_script"],
+                          arguments=arguments,
+                          compute_target=compute_target,
+                          environment=barf_env)
+    
+    if len(hyperparam_dict) > 0:
+        param_sampling = hyperdrive.GridParameterSampling(hyperparam_dict)
+        if "max_concurrent_runs" in run_config:
+            max_concurrent_runs = run_config["max_concurrent_runs"]
+            print("max concurrent runs set")
+        else:
+            max_concurrent_runs = None
+        hyperdrive_run_config = hyperdrive.HyperDriveConfig(run_config=src,
+                                    hyperparameter_sampling=param_sampling,
+                                    primary_metric_name=run_config["primary_metric_name"],
+                                    primary_metric_goal=hyperdrive.PrimaryMetricGoal.MINIMIZE,
+                                    max_total_runs=run_config["max_total_runs"],
+                                    max_concurrent_runs=max_concurrent_runs)
+    else:
+        print("No parameters to sample running a non-hyperdrive job")
+        hyperdrive_run_config = src
+
+    experiment_name = os.getlogin() + "-" + run_config["experiment_name"]
+
+    run_object = Experiment(workspace, name=experiment_name).submit(hyperdrive_run_config, tags={"run_name": args.run_name})
+    
+    import webbrowser
+    webbrowser.open_new(run_object.get_portal_url())

--- a/requirements_azureml.yaml
+++ b/requirements_azureml.yaml
@@ -1,0 +1,24 @@
+name: barf-env
+channels:
+  - conda-forge
+  - pytorch
+dependencies:
+  - numpy
+  - scipy
+  - tqdm
+  - termcolor
+  - easydict
+  - imageio
+  - ipdb
+  - pytorch>=1.9.0
+  - torchvision
+  - tensorboard
+  - visdom
+  - matplotlib
+  - scikit-video
+  - pyyaml
+  - pip
+  - gdown
+  - pip:
+    - azureml-core
+    - lpips

--- a/train_azureml.py
+++ b/train_azureml.py
@@ -1,0 +1,32 @@
+import numpy as np
+import os,sys,time
+import torch
+import importlib
+
+import options
+from util import log
+
+def main():
+
+    log.process(os.getpid())
+    log.title("[{}] (PyTorch code for training NeRF/BARF)".format(sys.argv[0]))
+
+    opt_cmd = options.parse_arguments_azureml(sys.argv[1:])
+    opt = options.set(opt_cmd=opt_cmd)
+    options.save_options_file(opt)
+
+    with torch.cuda.device(opt.device):
+
+        model = importlib.import_module("model.{}".format(opt.model))
+        m = model.Model(opt)
+
+        m.load_dataset(opt)
+        m.build_networks(opt)
+        m.setup_optimizer(opt)
+        m.restore_checkpoint(opt)
+        m.setup_visualizer(opt)
+
+        m.train(opt)
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
This Pull Request gives the option of running the training script on AzureML. To launch a training run, modify the config file in the azureml folder with your subscription ID, workspace name, etc. You can launch multiple runs with different hyperparameter settings by using the sampling, similarly to the default config file which launches 3 runs on different datasets. The PR made a new argument parser to be compatible with both the existing code and the AzureML argument format. There is also a new file, train_azureml.py which is identical to train.py except for the argument parser it uses.

This PR should enable more automated experimentation with the software, as well as enabling faster training through the use of cloud computing. 